### PR TITLE
Update Mapping Tools link

### DIFF
--- a/web/html/index.html
+++ b/web/html/index.html
@@ -256,10 +256,10 @@
                 <div class="panel">
                     <ul>
                         <li>
-                            <a target="_blank" href="https://mappingtools.seira.moe/"
+                            <a target="_blank" href="https://mappingtools.github.io/"
                                 >Mapping-Tools by Olibomby and Potoofu</a
                             >
-                            <code>https://mappingtools.seira.moe/</code>
+                            <code>https://mappingtools.github.io/</code>
                             <p>
                                 Program used for advanced slider creation, hitsounding, timing,
                                 among other helpful tools.


### PR DESCRIPTION
the seira.moe subdomain *does* redirect to the new github.io one but saving a redirect is nice, and would certainly help if the old subdomain stops working