### PR TITLE
fix osu.py link

### DIFF
--- a/web/html/index.html
+++ b/web/html/index.html
@@ -46,7 +46,7 @@
                         <a target="_blank" href="https://github.com/circleguard/ossapi">Python3 API</a>
                         <code>https://github.com/circleguard/ossapi</code>
                         <p>Support for both V1 and V2 of the API.</p>
-                        <a target="_blank" href="https://github.com/Sheeppsou/osu.py">Python3 API</a>
+                        <a target="_blank" href="https://github.com/Sheppsu/osu.py">Python3 API</a>
                         <code>https://github.com/Sheepposu/osu.py</code>
                         <p>Designed specifically for V2 of the API.</p>
                     </li>


### PR DESCRIPTION
I changed my github name a bit ago, so the link is outdated.