### PR TITLE
Add osu!track daily challenge site + beatmap atlas

### DIFF
--- a/web/html/index.html
+++ b/web/html/index.html
@@ -121,6 +121,12 @@
                             sorting for unachieved medals using osu! login.
                         </p>
                     </li>
+                    <li>
+                        <a target="_blank" href="https://ameobea.me/osutrack/daily-challenge/">osu!track Daily
+                            Challenge Leaderboard + Stats</a>
+                        <code>https://ameobea.me/osutrack/daily-challenge/</code>
+                        <p>Personal and global stats for the Lazer daily challenge</p>
+                    </li>
                 </ul>
             </div>
             <button class="accordion">
@@ -443,6 +449,14 @@
                         <p>
                             A Python library for reading beatmap files. Aims to implement lots of beatmap utility.
                             Some notable utility already implemented in built-in slider curve calculation.
+                        </p>
+                    </li>
+                    <li>
+                        <a target="_blank" href="https://osu-atlas.ameo.dev/">osu! Beatmap Atlas</a>
+                        <code>https://osu-atlas.ameo.dev/</code>
+                        <p>
+                            An interactive visualization of osu! beatmaps that places similar beatmaps close to
+                            each other in space.
                         </p>
                     </li>
                 </ul>


### PR DESCRIPTION
This adds two sites to the listing:

 - [osu!track Daily Challenge Leaderboard + Stats](https://ameobea.me/osutrack/daily-challenge/)
 - [osu! Beatmap Atlas](https://osu-atlas.ameo.dev)

Both are sites that I built pretty recently.  I came across your resource list and felt that they would be good inclusions on it.

Of course feel free to make any changes to my wording/descriptions etc. or ignore this PR if you'd rather not have them on the list.

In any case, tyvm for maintaining this very useful resource